### PR TITLE
카카오톡 소셜로그인 + JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-secret.properties

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -33,6 +34,14 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	//Swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
@@ -1,24 +1,33 @@
 package com.ema.ema_backend.domain.auth.controller;
 
+import com.ema.ema_backend.domain.auth.dto.KakaoLoginRequest;
+import com.ema.ema_backend.domain.auth.dto.TokenRefreshRequest;
 import com.ema.ema_backend.domain.auth.dto.TokenResponse;
+import com.ema.ema_backend.domain.auth.jwt.JwtProvider;
 import com.ema.ema_backend.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.token.TokenService;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
     private final AuthService authService;
+    private final JwtProvider jwtProvider;
 
-    @GetMapping("/oauth/kakao/login")
-    public ResponseEntity<TokenResponse> login(@RequestParam("code") String code) {
-        TokenResponse tokenResponse = authService.kakaoLogin(code);
+    @PostMapping("/oauth/kakao/login")
+    public ResponseEntity<TokenResponse> login(@RequestBody KakaoLoginRequest request) {
+        TokenResponse tokenResponse = authService.kakaoLogin(request.getCode());
 
         return ResponseEntity.ok().body(tokenResponse);
     }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@RequestBody TokenRefreshRequest request) {
+        TokenResponse tokenResponse = jwtProvider.refreshAccessToken(request.getRefreshToken());
+        return ResponseEntity.ok().body(tokenResponse);
+    }
+
 }

--- a/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
@@ -5,25 +5,48 @@ import com.ema.ema_backend.domain.auth.dto.TokenRefreshRequest;
 import com.ema.ema_backend.domain.auth.dto.TokenResponse;
 import com.ema.ema_backend.domain.auth.jwt.JwtProvider;
 import com.ema.ema_backend.domain.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.token.TokenService;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@Tag(name = "인증", description = "OAuth 및 토큰 관련 API")
 public class AuthController {
+
     private final AuthService authService;
     private final JwtProvider jwtProvider;
 
+    @Operation(
+            summary = "카카오 로그인",
+            description = "카카오 인가 코드를 통해 로그인하고 액세스/리프레시 토큰을 발급받습니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "로그인 성공",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponse.class))),
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content)
+            }
+    )
     @PostMapping("/oauth/kakao/login")
     public ResponseEntity<TokenResponse> login(@RequestBody KakaoLoginRequest request) {
         TokenResponse tokenResponse = authService.kakaoLogin(request.getCode());
-
         return ResponseEntity.ok().body(tokenResponse);
     }
 
+    @Operation(
+            summary = "토큰 재발급",
+            description = "리프레시 토큰을 이용해 새로운 액세스 토큰을 재발급합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "토큰 재발급 성공",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = TokenResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "리프레시 토큰 만료 또는 유효하지 않음", content = @Content)
+            }
+    )
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(@RequestBody TokenRefreshRequest request) {
         TokenResponse tokenResponse = jwtProvider.refreshAccessToken(request.getRefreshToken());

--- a/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.ema.ema_backend.domain.auth.controller;
 
 import com.ema.ema_backend.domain.auth.dto.TokenResponse;
-import com.ema.ema_backend.domain.member.service.MemberService;
+import com.ema.ema_backend.domain.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,11 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
-    private final MemberService memberService;
+    private final AuthService authService;
 
     @GetMapping("/oauth/kakao/login")
     public ResponseEntity<TokenResponse> login(@RequestParam("code") String code) {
-        TokenResponse tokenResponse = memberService.kakaoLogin(code);
+        TokenResponse tokenResponse = authService.kakaoLogin(code);
 
         return ResponseEntity.ok().body(tokenResponse);
     }

--- a/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.ema.ema_backend.domain.auth.controller;
 
-import com.ema.ema_backend.domain.auth.service.AuthService;
+import com.ema.ema_backend.domain.auth.dto.TokenResponse;
+import com.ema.ema_backend.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,11 +13,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
-    private final AuthService authService;
+    private final MemberService memberService;
 
     @GetMapping("/oauth/kakao/login")
-    public ResponseEntity<?> login(@RequestParam("code") String code) {
+    public ResponseEntity<TokenResponse> login(@RequestParam("code") String code) {
+        TokenResponse tokenResponse = memberService.kakaoLogin(code);
 
-        return ResponseEntity
+        return ResponseEntity.ok().body(tokenResponse);
     }
 }

--- a/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/controller/AuthController.java
@@ -1,0 +1,22 @@
+package com.ema.ema_backend.domain.auth.controller;
+
+import com.ema.ema_backend.domain.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    @GetMapping("/oauth/kakao/login")
+    public ResponseEntity<?> login(@RequestParam("code") String code) {
+
+        return ResponseEntity
+    }
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/dto/KakaoLoginRequest.java
@@ -1,0 +1,14 @@
+package com.ema.ema_backend.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class KakaoLoginRequest {
+    private String code;
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,23 @@
+package com.ema.ema_backend.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class KakaoTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("expires_in")
+    private int expiresIn;
+
+    @JsonProperty("refresh_token_expires_in")
+    private int refreshExpiresIn;
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/dto/KakaoUserResponse.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/dto/KakaoUserResponse.java
@@ -1,0 +1,28 @@
+package com.ema.ema_backend.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class KakaoUserResponse {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    // 내부 클래스
+    @Getter
+    @Setter
+    public static class KakaoAccount {
+        private String email;
+        private Profile profile;
+    }
+
+    @Getter
+    @Setter
+    public static class Profile {
+        private String nickname;
+    }
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,14 @@
+package com.ema.ema_backend.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class TokenRefreshRequest {
+    private String refreshToken;
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,12 @@
+package com.ema.ema_backend.domain.auth.dto;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/jwt/JwtFilter.java
@@ -38,6 +38,14 @@ public class JwtFilter extends OncePerRequestFilter {
             return;
         }
 
+        // Swagger 관련 경로는 JWT 필터 무시
+        if (requestURI.startsWith("/swagger-ui") || requestURI.startsWith("/v3/api-docs")) {
+            log.info("요청 URI: {}, Authorization: {}", requestURI, request.getHeader("Authorization"));
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String authHeader = request.getHeader("Authorization");
 
         if (authHeader != null && authHeader.startsWith("Bearer ")) {

--- a/src/main/java/com/ema/ema_backend/domain/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/jwt/JwtFilter.java
@@ -1,0 +1,59 @@
+package com.ema.ema_backend.domain.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    private static final List<String> EXCLUDED_URLS = List.of(
+            "/api/auth/oauth/kakao/login"
+    );
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestURI = request.getRequestURI();
+
+        // ✅ 특정 URL은 토큰 검증 생략
+        if (EXCLUDED_URLS.contains(requestURI)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+
+            try {
+                String email = jwtProvider.extractEmailFromAccessToken(token);
+
+                // 인증 객체 생성 및 SecurityContext 설정
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(email, null, null);
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } catch (Exception e) {
+                throw e;
+            }
+        }
+
+        filterChain.doFilter(request, response); // 토큰 없거나 정상 인증된 경우
+    }
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/jwt/JwtProvider.java
@@ -1,0 +1,93 @@
+package com.ema.ema_backend.domain.auth.jwt;
+
+import com.ema.ema_backend.domain.auth.dto.TokenResponse;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+//TODO: 싹다 예외처리 다시 할것
+@Service
+public class JwtProvider {
+    private static final long ACCESS_TEN_HOURS = 1000 * 60 * 60 * 24; //24시간
+
+    private static final long REFRESH_SEVEN_DAYS = 1000 * 60 * 60 * 24 * 7; //7일
+
+    private final Key secretKey;
+
+    public JwtProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] decodedKey = Base64.getDecoder().decode(secretKey);
+        this.secretKey = new SecretKeySpec(decodedKey, 0, decodedKey.length, "HmacSHA256");
+    }
+
+    public String generateAccessToken(String email) {
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("tokenType", "access")
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TEN_HOURS))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(String email) {
+
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("tokenType", "refresh")
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_SEVEN_DAYS))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+
+    public String extractEmailFromAccessToken(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+        if (!"access".equals(claims.get("tokenType", String.class))) {
+            throw new RuntimeException("사용된 토큰이 엑세스 토큰이 아닙니다. 요청하신 로직에서는 엑세스 토큰으로만 처리가 가능합니다.");
+        }
+        if (claims.getExpiration().before(new Date())) {
+            throw new RuntimeException("액세스 토큰이 만료되었습니다. 리프레시 토큰으로 다시 액세스 토큰을 발급받으세요.");
+        }
+        return claims.getSubject();
+    }
+
+    public String extractEmailFromRefreshToken(String refreshToken) {
+        Claims claims = parseClaims(refreshToken);
+        if (!"refresh".equals(claims.get("tokenType", String.class))) {
+            throw new RuntimeException("해당 토큰은 리프레쉬 토큰이 아닙니다. 요청하신 로직에서는 리프레쉬 토큰만 사용이 가능합니다.");
+        }
+        if (claims.getExpiration().before(new Date())) {
+            throw new RuntimeException("리프레쉬 토큰이 만료되었습니다. 재로그인을 하세요.");
+        }
+        return claims.getSubject();
+    }
+
+    public Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    public TokenResponse refreshAccessToken(String refreshToken) {
+        String email = extractEmailFromRefreshToken(refreshToken);
+
+        String newAccessToken = generateAccessToken(email);
+        String newRefreshToken = generateRefreshToken(email);
+
+        return new TokenResponse(newAccessToken, newRefreshToken);
+    }
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/properties/KakaoProperties.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/properties/KakaoProperties.java
@@ -1,0 +1,14 @@
+package com.ema.ema_backend.domain.auth.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "kakao")
+@Getter @Setter
+public class KakaoProperties {
+    private String clientId;
+    private String redirectUri;
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/service/AuthService.java
@@ -45,6 +45,7 @@ public class AuthService {
 
     }
 
+
     private void registerMemberIfNotExist(String nickname, String email) {
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
 
@@ -52,4 +53,5 @@ public class AuthService {
             memberService.registerNewMember(nickname, email);
         }
     }
+
 }

--- a/src/main/java/com/ema/ema_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/service/AuthService.java
@@ -1,0 +1,10 @@
+package com.ema.ema_backend.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/service/AuthService.java
@@ -1,10 +1,55 @@
 package com.ema.ema_backend.domain.auth.service;
 
+import com.ema.ema_backend.domain.auth.dto.KakaoTokenResponse;
+import com.ema.ema_backend.domain.auth.dto.KakaoUserResponse;
+import com.ema.ema_backend.domain.auth.dto.TokenResponse;
+import com.ema.ema_backend.domain.auth.jwt.JwtProvider;
+import com.ema.ema_backend.domain.member.entity.Member;
+import com.ema.ema_backend.domain.member.repository.MemberRepository;
+import com.ema.ema_backend.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
 
+    private final MemberRepository memberRepository;
+    private final MemberService memberService;
+    private final KakaoApiService kakaoApiService;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public TokenResponse kakaoLogin(String code) {
+        KakaoTokenResponse tokenResponse = kakaoApiService.getAccessToken(code);
+        KakaoUserResponse userResponse = kakaoApiService.getUserInfo(tokenResponse.getAccessToken());
+
+        String email = userResponse.getKakaoAccount().getEmail();
+        String nickname = userResponse.getKakaoAccount().getProfile().getNickname();
+
+        log.info("카카오 로그인 요청 email: {}, nickname: {}", email, nickname);
+
+        //TODO: kakao 토큰 저장 전용 테이블을 만들어야할듯?
+
+        registerMemberIfNotExist(nickname, email);
+
+        String accessToken = jwtProvider.generateAccessToken(email);
+        String refreshToken = jwtProvider.generateRefreshToken(email);
+
+        return new TokenResponse(accessToken, refreshToken);
+
+    }
+
+    private void registerMemberIfNotExist(String nickname, String email) {
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+
+        if (optionalMember.isEmpty()) {
+            memberService.registerNewMember(nickname, email);
+        }
+    }
 }

--- a/src/main/java/com/ema/ema_backend/domain/auth/service/KakaoApiService.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/service/KakaoApiService.java
@@ -3,6 +3,7 @@ package com.ema.ema_backend.domain.auth.service;
 import com.ema.ema_backend.domain.auth.dto.KakaoTokenResponse;
 import com.ema.ema_backend.domain.auth.dto.KakaoUserResponse;
 import com.ema.ema_backend.domain.auth.properties.KakaoProperties;
+import com.ema.ema_backend.global.exception.ExternalApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
@@ -66,7 +67,7 @@ public class KakaoApiService {
 
         log.info("카카오 사용자 정보 응답 JSON: {}", response.getBody());
         if (response.getBody().getKakaoAccount().getEmail() == null) {
-            throw new RuntimeException("카카오 계정으로부터 전달받은 이메일이 없습니다.");
+            throw new ExternalApiException("카카오 계정으로부터 전달받은 이메일이 없습니다.");
         }
         return response.getBody();
     }

--- a/src/main/java/com/ema/ema_backend/domain/auth/service/KakaoApiService.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/service/KakaoApiService.java
@@ -1,0 +1,67 @@
+package com.ema.ema_backend.domain.auth.service;
+
+import com.ema.ema_backend.domain.auth.dto.KakaoTokenResponse;
+import com.ema.ema_backend.domain.auth.dto.KakaoUserResponse;
+import com.ema.ema_backend.domain.auth.properties.KakaoProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoApiService {
+    private static final String KAKAO_AUTH_BASE_URL = "https://kauth.kakao.com/oauth";
+    private static final String KAKAO_API_BASE_URL = "https://kapi.kakao.com/v2/user";
+
+    private final RestTemplate restTemplate;
+    private final KakaoProperties kakaoProperties;
+
+
+    public KakaoTokenResponse getAccessToken(String authorizationCode) {
+        String url = KAKAO_AUTH_BASE_URL + "/token";
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
+
+        String redirectUri = kakaoProperties.getRedirectUri();
+
+        LinkedMultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoProperties.getClientId());
+        body.add("redirect_uri", redirectUri);
+        body.add("code", authorizationCode);
+
+        RequestEntity<LinkedMultiValueMap<String, String>> request = new RequestEntity<>(body,
+                headers, HttpMethod.POST, URI.create(url));
+
+        ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(request,
+                KakaoTokenResponse.class);
+
+        return response.getBody();
+    }
+
+    public KakaoUserResponse getUserInfo(String accessToken) {
+        String url = KAKAO_API_BASE_URL + "/me";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setBearerAuth(accessToken);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("property_keys", "[\"kakao_account.email\", \"kakao_account.profile\"]");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
+                url, HttpMethod.POST, request, KakaoUserResponse.class);
+
+        if (response.getBody().getKakaoAccount().getEmail() == null) {
+            throw new RuntimeException("카카오 계정으로부터 전달받은 이메일이 없습니다.");
+        }
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/ema/ema_backend/domain/auth/service/KakaoApiService.java
+++ b/src/main/java/com/ema/ema_backend/domain/auth/service/KakaoApiService.java
@@ -25,12 +25,10 @@ public class KakaoApiService {
 
 
     public KakaoTokenResponse getAccessToken(String authorizationCode) {
-        log.info("authorizationCode: {}", authorizationCode);
+        log.info("카카오 인가코드: {}", authorizationCode);
         String url = KAKAO_AUTH_BASE_URL + "/token";
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE);
-
-        log.info("kakaoProperties: {}, {}", kakaoProperties.getClientId(), kakaoProperties.getRedirectUri());
 
         String redirectUri = kakaoProperties.getRedirectUri();
 
@@ -42,20 +40,17 @@ public class KakaoApiService {
 
         RequestEntity<LinkedMultiValueMap<String, String>> request = new RequestEntity<>(body,
                 headers, HttpMethod.POST, URI.create(url));
-        log.info("request: {}", request);
 
         ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(request,
                 KakaoTokenResponse.class);
-        log.info("Status code: {}", response.getStatusCodeValue());
-        log.info("Raw body: {}", response.getBody());
 
-        log.info("kakao raw response: {}", response.getBody().getAccessToken());
+        log.info("카카오 accessToken: {}", response.getBody().getAccessToken());
 
         return response.getBody();
     }
 
+    //TODO: GET요청으로 바꾸기
     public KakaoUserResponse getUserInfo(String accessToken) {
-        log.info("accessToken: {}", accessToken);
         String url = KAKAO_API_BASE_URL + "/me";
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.valueOf("application/x-www-form-urlencoded;charset=utf-8"));
@@ -70,12 +65,9 @@ public class KakaoApiService {
                 url, HttpMethod.POST, request, KakaoUserResponse.class);
 
         log.info("카카오 사용자 정보 응답 JSON: {}", response.getBody());
-        log.info("Raw body: {}", response.getBody());
-        log.info("getKakaoAccount(): {}", response.getBody().getKakaoAccount());
         if (response.getBody().getKakaoAccount().getEmail() == null) {
             throw new RuntimeException("카카오 계정으로부터 전달받은 이메일이 없습니다.");
         }
-
         return response.getBody();
     }
 }

--- a/src/main/java/com/ema/ema_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/ema/ema_backend/domain/member/entity/Member.java
@@ -1,0 +1,25 @@
+package com.ema.ema_backend.domain.member.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @NotBlank
+    private String name;
+
+    @Column(nullable = false)
+    @Email
+    private String email;
+}

--- a/src/main/java/com/ema/ema_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/ema/ema_backend/domain/member/entity/Member.java
@@ -27,7 +27,7 @@ public class Member {
         this.name = name;
         this.email = email;
     }
-    public static Member create(String name, String email) {
+    public static Member createByNameAndEmail(String name, String email) {
         return new Member(name, email);
     }
 }

--- a/src/main/java/com/ema/ema_backend/domain/member/entity/Member.java
+++ b/src/main/java/com/ema/ema_backend/domain/member/entity/Member.java
@@ -19,7 +19,15 @@ public class Member {
     @NotBlank
     private String name;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     @Email
     private String email;
+
+    private Member(String name, String email) {
+        this.name = name;
+        this.email = email;
+    }
+    public static Member create(String name, String email) {
+        return new Member(name, email);
+    }
 }

--- a/src/main/java/com/ema/ema_backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ema/ema_backend/domain/member/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package com.ema.ema_backend.domain.member.repository;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepository {
+    private final EntityManager em;
+
+    public void save(Member member) {}
+}

--- a/src/main/java/com/ema/ema_backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ema/ema_backend/domain/member/repository/MemberRepository.java
@@ -1,13 +1,31 @@
 package com.ema.ema_backend.domain.member.repository;
 
+import com.ema.ema_backend.domain.member.entity.Member;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
 public class MemberRepository {
     private final EntityManager em;
 
-    public void save(Member member) {}
+    public Long save(Member member) {
+        em.persist(member);
+        return member.getId();
+    }
+
+    public Optional<Member> findByEmail(String email) {
+        String jpql = "select m from Member m where m.email = :email";
+        Optional<Member> findMember = em.createQuery(jpql, Member.class)
+                .setParameter("email", email)
+                .getResultList()
+                .stream().findFirst();
+
+        return findMember;
+    }
+
 }

--- a/src/main/java/com/ema/ema_backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/ema/ema_backend/domain/member/service/MemberService.java
@@ -1,9 +1,7 @@
 package com.ema.ema_backend.domain.member.service;
 
-import com.ema.ema_backend.domain.auth.service.KakaoApiService;
 import com.ema.ema_backend.domain.member.entity.Member;
 import com.ema.ema_backend.domain.member.repository.MemberRepository;
-import com.ema.ema_backend.domain.auth.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/ema/ema_backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/ema/ema_backend/domain/member/service/MemberService.java
@@ -1,8 +1,5 @@
 package com.ema.ema_backend.domain.member.service;
 
-import com.ema.ema_backend.domain.auth.dto.KakaoTokenResponse;
-import com.ema.ema_backend.domain.auth.dto.KakaoUserResponse;
-import com.ema.ema_backend.domain.auth.dto.TokenResponse;
 import com.ema.ema_backend.domain.auth.service.KakaoApiService;
 import com.ema.ema_backend.domain.member.entity.Member;
 import com.ema.ema_backend.domain.member.repository.MemberRepository;
@@ -11,43 +8,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class MemberService {
     private final MemberRepository memberRepository;
-    private final KakaoApiService kakaoApiService;
-    private final JwtProvider jwtProvider;
 
-    public TokenResponse kakaoLogin(String code) {
-        KakaoTokenResponse tokenResponse = kakaoApiService.getAccessToken(code);
-        KakaoUserResponse userResponse = kakaoApiService.getUserInfo(tokenResponse.getAccessToken());
-
-        String email = userResponse.getKakaoAccount().getEmail();
-
-        //TODO: 토큰 저장 kakao 전용 테이블을 만들어야할듯?
-
-        Optional<Member> optionalMember = memberRepository.findByEmail(email);
-
-        if (optionalMember.isEmpty()) {
-            registerNewMember(userResponse.getKakaoAccount().getEmail(), userResponse.getKakaoAccount().getProfile().getNickname());
-        }
-
-        String accessToken = jwtProvider.generateAccessToken(email);
-        String refreshToken = jwtProvider.generateRefreshToken(email);
-
-        return new TokenResponse(accessToken, refreshToken);
-
-    }
-
-    private void registerNewMember(String email, String nickname) {
+    public void registerNewMember(String nickname, String email) {
         if (memberRepository.findByEmail(email).isPresent()) {
             //TODO: 예외처리 다시 할것 커스텀 예외로
             throw new RuntimeException("이미 존재하는 이메일입니다.");
         }
-        Member member = Member.create(nickname, email);
+        Member member = Member.createByNameAndEmail(nickname, email);
         memberRepository.save(member);
     }
 }

--- a/src/main/java/com/ema/ema_backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/ema/ema_backend/domain/member/service/MemberService.java
@@ -1,0 +1,53 @@
+package com.ema.ema_backend.domain.member.service;
+
+import com.ema.ema_backend.domain.auth.dto.KakaoTokenResponse;
+import com.ema.ema_backend.domain.auth.dto.KakaoUserResponse;
+import com.ema.ema_backend.domain.auth.dto.TokenResponse;
+import com.ema.ema_backend.domain.auth.service.KakaoApiService;
+import com.ema.ema_backend.domain.member.entity.Member;
+import com.ema.ema_backend.domain.member.repository.MemberRepository;
+import com.ema.ema_backend.domain.auth.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final KakaoApiService kakaoApiService;
+    private final JwtProvider jwtProvider;
+
+    public TokenResponse kakaoLogin(String code) {
+        KakaoTokenResponse tokenResponse = kakaoApiService.getAccessToken(code);
+        KakaoUserResponse userResponse = kakaoApiService.getUserInfo(tokenResponse.getAccessToken());
+
+        String email = userResponse.getKakaoAccount().getEmail();
+
+        //TODO: 토큰 저장 kakao 전용 테이블을 만들어야할듯?
+
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+
+        if (optionalMember.isEmpty()) {
+            registerNewMember(userResponse.getKakaoAccount().getEmail(), userResponse.getKakaoAccount().getProfile().getNickname());
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(email);
+        String refreshToken = jwtProvider.generateRefreshToken(email);
+
+        return new TokenResponse(accessToken, refreshToken);
+
+    }
+
+    private void registerNewMember(String email, String nickname) {
+        if (memberRepository.findByEmail(email).isPresent()) {
+            //TODO: 예외처리 다시 할것 커스텀 예외로
+            throw new RuntimeException("이미 존재하는 이메일입니다.");
+        }
+        Member member = Member.create(nickname, email);
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/com/ema/ema_backend/global/config/RestTemplateResponseErrorHandler.java
+++ b/src/main/java/com/ema/ema_backend/global/config/RestTemplateResponseErrorHandler.java
@@ -1,0 +1,45 @@
+package com.ema.ema_backend.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import java.io.IOException;
+import java.net.URI;
+
+@Slf4j
+@Component
+public class RestTemplateResponseErrorHandler implements ResponseErrorHandler {
+
+    @Override
+    public boolean hasError(ClientHttpResponse response) throws IOException {
+        HttpStatusCode statusCode = response.getStatusCode();
+        return statusCode.is4xxClientError() || statusCode.is5xxServerError();
+    }
+
+    @Override
+    public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
+        HttpStatusCode statusCode = response.getStatusCode();
+        String body = new String(response.getBody().readAllBytes());
+
+        if (statusCode.is4xxClientError()) {
+            log.error("클라이언트 에러 - URL: {}, Method: {}, Status: {} - ResponseBody: {}",
+                    url, method, statusCode, body);
+            throw new HttpClientErrorException(statusCode, response.getStatusText(),
+                    response.getHeaders(), body.getBytes(), null);
+        }
+
+        if (statusCode.is5xxServerError()) {
+            log.error("서버 에러 - URL: {}, Method: {}, Status: {} - ResponseBody: {}",
+                    url, method, statusCode, body);
+            throw new HttpServerErrorException(statusCode, response.getStatusText(),
+                    response.getHeaders(), body.getBytes(), null);
+        }
+    }
+
+}

--- a/src/main/java/com/ema/ema_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ema/ema_backend/global/config/SecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @EnableWebSecurity
@@ -30,7 +32,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/oauth/kakao/login",
-                                "/api/auth/refresh"
+                                "/api/auth/refresh",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**"
+
                         ).permitAll() // 인증 없이 접근 가능
 
                         .anyRequest().authenticated() // 그 외는 인증 필요

--- a/src/main/java/com/ema/ema_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ema/ema_backend/global/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.ema.ema_backend.global.config;
+
+import com.ema.ema_backend.domain.auth.jwt.JwtFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // ✅ CSRF 비활성화 (JWT는 세션이 없기 때문에)
+                .csrf(AbstractHttpConfigurer::disable)
+
+                // ✅ 세션 정책을 Stateless로 설정
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // ✅ URL별 인증 설정
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/oauth/kakao/login"
+                        ).permitAll() // 인증 없이 접근 가능
+
+                        .anyRequest().authenticated() // 그 외는 인증 필요
+                )
+
+                // ✅ JwtFilter를 UsernamePasswordAuthenticationFilter 전에 삽입
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/ema/ema_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/ema/ema_backend/global/config/SecurityConfig.java
@@ -20,22 +20,23 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // ✅ CSRF 비활성화 (JWT는 세션이 없기 때문에)
+                // CSRF 비활성화 (JWT는 세션이 없기 때문에)
                 .csrf(AbstractHttpConfigurer::disable)
 
-                // ✅ 세션 정책을 Stateless로 설정
+                // 세션 정책을 Stateless로 설정
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-                // ✅ URL별 인증 설정
+                // URL별 인증 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/oauth/kakao/login"
+                                "/api/auth/oauth/kakao/login",
+                                "/api/auth/refresh"
                         ).permitAll() // 인증 없이 접근 가능
 
                         .anyRequest().authenticated() // 그 외는 인증 필요
                 )
 
-                // ✅ JwtFilter를 UsernamePasswordAuthenticationFilter 전에 삽입
+                // JwtFilter를 UsernamePasswordAuthenticationFilter 전에 삽입
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/ema/ema_backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ema/ema_backend/global/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.ema.ema_backend.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(title = "EMA API 명세서", version = "v1", description = "공학수학 학습 플랫폼 Swagger 문서")
+)
+@SecurityScheme(
+        name = "JWT",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+@Configuration
+public class SwaggerConfig {
+}

--- a/src/main/java/com/ema/ema_backend/global/config/WebConfig.java
+++ b/src/main/java/com/ema/ema_backend/global/config/WebConfig.java
@@ -1,0 +1,13 @@
+package com.ema.ema_backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/ema/ema_backend/global/exception/BadRequestException.java
+++ b/src/main/java/com/ema/ema_backend/global/exception/BadRequestException.java
@@ -1,0 +1,2 @@
+package com.ema.ema_backend.global.exception;public class BadRequestException {
+}

--- a/src/main/java/com/ema/ema_backend/global/exception/BadRequestException.java
+++ b/src/main/java/com/ema/ema_backend/global/exception/BadRequestException.java
@@ -1,2 +1,8 @@
-package com.ema.ema_backend.global.exception;public class BadRequestException {
+package com.ema.ema_backend.global.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+
 }

--- a/src/main/java/com/ema/ema_backend/global/exception/ExternalApiException.java
+++ b/src/main/java/com/ema/ema_backend/global/exception/ExternalApiException.java
@@ -1,0 +1,7 @@
+package com.ema.ema_backend.global.exception;
+
+public class ExternalApiException extends RuntimeException{
+    public ExternalApiException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/ema/ema_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ema/ema_backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,8 @@
+package com.ema.ema_backend.global.exception;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+}

--- a/src/main/java/com/ema/ema_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ema/ema_backend/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,34 @@
 package com.ema.ema_backend.global.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ExternalApiException.class)
+    public ResponseEntity<ProblemDetail> handleBadResponseException(ExternalApiException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_GATEWAY, e.getMessage());
+        problemDetail.setTitle("BAD_GATEWAY");
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY).body(problemDetail);
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ProblemDetail> handleBadResponseException(BadRequestException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        problemDetail.setTitle("BAD_REQUEST");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problemDetail);
+    }
+
+    @ExceptionHandler(TokenExpiredException.class)
+    public ResponseEntity<ProblemDetail> handleBadResponseException(TokenExpiredException e) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, e.getMessage());
+        problemDetail.setTitle("ACCESS_TOKEN_EXPIRED");
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(problemDetail);
+    }
+
 
 }

--- a/src/main/java/com/ema/ema_backend/global/exception/TokenExpiredException.java
+++ b/src/main/java/com/ema/ema_backend/global/exception/TokenExpiredException.java
@@ -1,4 +1,7 @@
 package com.ema.ema_backend.global.exception;
 
-public class TokenExpiredException {
+public class TokenExpiredException extends RuntimeException {
+    public TokenExpiredException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/ema/ema_backend/global/exception/TokenExpiredException.java
+++ b/src/main/java/com/ema/ema_backend/global/exception/TokenExpiredException.java
@@ -1,0 +1,4 @@
+package com.ema.ema_backend.global.exception;
+
+public class TokenExpiredException {
+}

--- a/src/main/java/com/ema/ema_backend/global/security/JwtFilter.java
+++ b/src/main/java/com/ema/ema_backend/global/security/JwtFilter.java
@@ -1,4 +1,0 @@
-package com.ema.ema_backend.global.security;
-
-public class JwtFilter {
-}

--- a/src/main/java/com/ema/ema_backend/global/security/JwtFilter.java
+++ b/src/main/java/com/ema/ema_backend/global/security/JwtFilter.java
@@ -1,0 +1,4 @@
+package com.ema.ema_backend.global.security;
+
+public class JwtFilter {
+}

--- a/src/main/java/com/ema/ema_backend/global/security/JwtProvider.java
+++ b/src/main/java/com/ema/ema_backend/global/security/JwtProvider.java
@@ -1,4 +1,0 @@
-package com.ema.ema_backend.global.security;
-
-public class JwtProvider {
-}

--- a/src/main/java/com/ema/ema_backend/global/security/JwtProvider.java
+++ b/src/main/java/com/ema/ema_backend/global/security/JwtProvider.java
@@ -1,0 +1,4 @@
+package com.ema.ema_backend.global.security;
+
+public class JwtProvider {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,15 @@ spring.servlet.multipart.enabled=false
 server.servlet.encoding.charset=UTF-8
 server.servlet.encoding.force=true
 
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.api-docs.path=/v3/api-docs
+
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+spring.sql.init.mode=always
+
 spring.jackson.serialization.indent-output=true
 
 kakao.client-id=${kakao.client-id}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
 spring.application.name=ema-backend
+spring.profiles.include=secret
+
+spring.servlet.multipart.enabled=false
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.force=true
+
+spring.jackson.serialization.indent-output=true
+
+kakao.client-id=${kakao.client-id}
+kakao.redirect-uri=${kakao.redirect-uri}
+


### PR DESCRIPTION
## 🔧 작업 내용
- **API 1**: 프론트에서 인가코드 -> 카카오톡에 accessToken요청 -> 카카오톡에 사용자 정보 요청 -> email로 JWT생성 -> 프론트로 전달
- **API 2**: 프론트에서 accessToken 만료시 재발급 요청 -> body에 refreshToken으로 accessToken 재발급
- ```JwtFilter```: controller 접근 이전에 jwt 검증
- ```JwtProvider```: accessToken 생성, refreshToken 생성, 토큰에서 email 뽑기
- ```GlobalExceptionHandler```: 전역예외처리
- ```RestTemplateResponseErrorHandler```: RestTemplate으로 카카오에 요청보낼 때 Error 핸들러
- ```Repository```: 일단 JPA로만 구현했는데, 차후에 Spring Data JPA로 바꿔도 될듯. 지금은 저게 익숙해서..
- 저번에 key들 .env파일에서 환경변수로 관리하는 방법이 있었던 것 같은데 까먹었음. 이점도 까먹었음. 다시 설명해주시길 현재는 application-secret.properties로 하는중

## 📌 참고 사항
음 일단 당장 발표자료 만들어야하고, 그럼 agent 아키택쳐 짜는게 중요할듯

그래서 일단 랭체인/그래프 스터디가 중요할듯

나도 다시 스터디 들어갈 예정

백으로서는 카카오톡의 accesstoken 을 관리할 엔티티를 따로 만들어야하나? 하는 생각

또한 프론트에서 미리 배포 잠깐 해주면 좋겠다는 의견이 있었음

## ✓ Git close
 - Resolve #1 